### PR TITLE
Fixes #2 GCC 4.9.0 and NAN v2.x syntax issues

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,0 +1,231 @@
+{
+  "name": "bgzf",
+  "version": "0.0.1",
+  "dependencies": {
+    "abbrev": {
+      "version": "1.0.9",
+      "from": "abbrev@>=1.0.0 <2.0.0",
+      "resolved": "http://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz"
+    },
+    "ansi-styles": {
+      "version": "1.0.0",
+      "from": "ansi-styles@>=1.0.0 <1.1.0",
+      "resolved": "http://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz"
+    },
+    "argparse": {
+      "version": "0.1.16",
+      "from": "argparse@>=0.1.11 <0.2.0",
+      "resolved": "http://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
+      "dependencies": {
+        "underscore.string": {
+          "version": "2.4.0",
+          "from": "underscore.string@>=2.4.0 <2.5.0",
+          "resolved": "http://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz"
+        }
+      }
+    },
+    "async": {
+      "version": "0.1.22",
+      "from": "async@>=0.1.22 <0.2.0",
+      "resolved": "http://registry.npmjs.org/async/-/async-0.1.22.tgz"
+    },
+    "chalk": {
+      "version": "0.4.0",
+      "from": "chalk@>=0.4.0 <0.5.0",
+      "resolved": "http://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz"
+    },
+    "colors": {
+      "version": "0.6.2",
+      "from": "colors@>=0.6.2 <0.7.0",
+      "resolved": "http://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
+    },
+    "dateformat": {
+      "version": "1.0.2-1.2.3",
+      "from": "dateformat@1.0.2-1.2.3",
+      "resolved": "http://registry.npmjs.org/dateformat/-/dateformat-1.0.2-1.2.3.tgz"
+    },
+    "esprima": {
+      "version": "1.0.4",
+      "from": "esprima@>=1.0.2 <1.1.0",
+      "resolved": "http://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
+    },
+    "eventemitter2": {
+      "version": "0.4.14",
+      "from": "eventemitter2@>=0.4.13 <0.5.0",
+      "resolved": "http://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz"
+    },
+    "exit": {
+      "version": "0.1.2",
+      "from": "exit@>=0.1.1 <0.2.0",
+      "resolved": "http://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
+    },
+    "findup-sync": {
+      "version": "0.1.3",
+      "from": "findup-sync@>=0.1.2 <0.2.0",
+      "resolved": "http://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
+      "dependencies": {
+        "glob": {
+          "version": "3.2.11",
+          "from": "glob@>=3.2.9 <3.3.0",
+          "resolved": "http://registry.npmjs.org/glob/-/glob-3.2.11.tgz"
+        },
+        "lodash": {
+          "version": "2.4.2",
+          "from": "lodash@>=2.4.1 <2.5.0",
+          "resolved": "http://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
+        },
+        "minimatch": {
+          "version": "0.3.0",
+          "from": "minimatch@>=0.3.0 <0.4.0",
+          "resolved": "http://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz"
+        }
+      }
+    },
+    "getobject": {
+      "version": "0.1.0",
+      "from": "getobject@>=0.1.0 <0.2.0",
+      "resolved": "http://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz"
+    },
+    "glob": {
+      "version": "3.1.21",
+      "from": "glob@>=3.1.21 <3.2.0",
+      "resolved": "http://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+      "dependencies": {
+        "inherits": {
+          "version": "1.0.2",
+          "from": "inherits@>=1.0.0 <2.0.0",
+          "resolved": "http://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz"
+        }
+      }
+    },
+    "graceful-fs": {
+      "version": "1.2.3",
+      "from": "graceful-fs@>=1.2.0 <1.3.0",
+      "resolved": "http://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
+    },
+    "grunt-legacy-log": {
+      "version": "0.1.3",
+      "from": "grunt-legacy-log@>=0.1.0 <0.2.0",
+      "resolved": "http://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-0.1.3.tgz",
+      "dependencies": {
+        "lodash": {
+          "version": "2.4.2",
+          "from": "lodash@>=2.4.1 <2.5.0",
+          "resolved": "http://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
+        },
+        "underscore.string": {
+          "version": "2.3.3",
+          "from": "underscore.string@>=2.3.3 <2.4.0",
+          "resolved": "http://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
+        }
+      }
+    },
+    "grunt-legacy-log-utils": {
+      "version": "0.1.1",
+      "from": "grunt-legacy-log-utils@>=0.1.1 <0.2.0",
+      "resolved": "http://registry.npmjs.org/grunt-legacy-log-utils/-/grunt-legacy-log-utils-0.1.1.tgz",
+      "dependencies": {
+        "lodash": {
+          "version": "2.4.2",
+          "from": "lodash@>=2.4.1 <2.5.0",
+          "resolved": "http://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
+        },
+        "underscore.string": {
+          "version": "2.3.3",
+          "from": "underscore.string@>=2.3.3 <2.4.0",
+          "resolved": "http://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
+        }
+      }
+    },
+    "grunt-legacy-util": {
+      "version": "0.2.0",
+      "from": "grunt-legacy-util@>=0.2.0 <0.3.0",
+      "resolved": "http://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz"
+    },
+    "has-color": {
+      "version": "0.1.7",
+      "from": "has-color@>=0.1.0 <0.2.0",
+      "resolved": "http://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
+    },
+    "hooker": {
+      "version": "0.2.3",
+      "from": "hooker@>=0.2.3 <0.3.0",
+      "resolved": "http://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
+    },
+    "iconv-lite": {
+      "version": "0.2.11",
+      "from": "iconv-lite@>=0.2.11 <0.3.0",
+      "resolved": "http://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz"
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "from": "inherits@>=2.0.0 <3.0.0",
+      "resolved": "http://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+    },
+    "js-yaml": {
+      "version": "2.0.5",
+      "from": "js-yaml@>=2.0.5 <2.1.0",
+      "resolved": "http://registry.npmjs.org/js-yaml/-/js-yaml-2.0.5.tgz"
+    },
+    "lodash": {
+      "version": "0.9.2",
+      "from": "lodash@>=0.9.2 <0.10.0",
+      "resolved": "http://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz"
+    },
+    "lru-cache": {
+      "version": "2.7.3",
+      "from": "lru-cache@>=2.0.0 <3.0.0",
+      "resolved": "http://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
+    },
+    "minimatch": {
+      "version": "0.2.14",
+      "from": "minimatch@>=0.2.12 <0.3.0",
+      "resolved": "http://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz"
+    },
+    "mkdirp": {
+      "version": "0.3.5",
+      "from": "mkdirp@>=0.3.5 <0.4.0",
+      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
+    },
+    "nan": {
+      "version": "2.4.0",
+      "from": "nan@>=2.0.0 <3.0.0",
+      "resolved": "http://registry.npmjs.org/nan/-/nan-2.4.0.tgz"
+    },
+    "nopt": {
+      "version": "1.0.10",
+      "from": "nopt@>=1.0.10 <1.1.0",
+      "resolved": "http://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz"
+    },
+    "rimraf": {
+      "version": "2.2.8",
+      "from": "rimraf@>=2.2.8 <2.3.0",
+      "resolved": "http://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
+    },
+    "sigmund": {
+      "version": "1.0.1",
+      "from": "sigmund@>=1.0.0 <1.1.0",
+      "resolved": "http://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+    },
+    "strip-ansi": {
+      "version": "0.1.1",
+      "from": "strip-ansi@>=0.1.0 <0.2.0",
+      "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz"
+    },
+    "underscore": {
+      "version": "1.7.0",
+      "from": "underscore@>=1.7.0 <1.8.0",
+      "resolved": "http://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz"
+    },
+    "underscore.string": {
+      "version": "2.2.1",
+      "from": "underscore.string@>=2.2.1 <2.3.0",
+      "resolved": "http://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz"
+    },
+    "which": {
+      "version": "1.0.9",
+      "from": "which@>=1.0.5 <1.1.0",
+      "resolved": "http://registry.npmjs.org/which/-/which-1.0.9.tgz"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,10 +1,21 @@
 {
   "name": "bgzf",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "description": "inflate BGZF format(sync)",
   "main": "index.js",
   "homepage": "http://github.com/shinout/bgzf",
   "author": "Shin Suzuki<shinout310@gmail.com>",
+  "contributors": [
+      {
+	  "name": "Shin Suzuki",
+	  "email": "shinout310@gmail.com"
+      },
+      {
+	  "name": "Matthew Ralston",
+	  "email": "mrals89@gmail.com",
+	  "url": "http://MatthewRalston.github.io"
+      }
+  ],
   "gypfile": true,
   "keywords": [
     "bgzf",
@@ -21,7 +32,7 @@
     "node": ">= 0.8.0"
   },
   "dependencies": {
-    "nan": "*"
+    "nan": "^2.0.x"
   },
   "devDependencies": {
     "coffee-script": ">= 1.7.1",

--- a/src/bgzf.cc
+++ b/src/bgzf.cc
@@ -1,5 +1,6 @@
 #include <node.h>
 #include <nan.h>
+#include <node_buffer.h>
 
 #include <zlib.h>
 #include <cstring>
@@ -13,23 +14,27 @@ using v8::Object;
 using v8::String;
 using v8::Number;
 using v8::Local;
-using node::Buffer;
-
-#define ERR(msg) v8::ThrowException(v8::Exception::Error(String::New(msg)));
+using namespace node::Buffer;
 
 // function to export
-NAN_METHOD(InflateRawSync) {
-  NanScope();
 
-  if(args.Length() < 2 || !Buffer::HasInstance(args[0]) || !Buffer::HasInstance(args[1])) {
-    return ERR("arguments must be Buffer objects")
+void inflateRawSync(const Nan::FunctionCallbackInfo<v8::Value>& info){
+  Nan::HandleScope scope;
+
+  if(info.Length() < 2){
+    Nan::ThrowTypeError("Wrong number of arguments. Requires 2 buffer objects");
+    return;
   }
-  Local<Object> input  = args[0]->ToObject();
-  Local<Object> result = args[1]->ToObject();
-  Bytef* in_buf  = (Bytef*)Buffer::Data(input);
-  Bytef* res_buf = (Bytef*)Buffer::Data(result);
-  int in_len  = Buffer::Length(input);
-  int res_len = Buffer::Length(result);
+  if (!node::Buffer::HasInstance(info[0]) || !node::Buffer::HasInstance(info[1])) {
+    Nan::ThrowTypeError("One or more arguments has invalid type. Requires 2 buffer objects");
+    return;
+  }
+  Local<Object> input  = info[0]->ToObject();
+  Local<Object> result = info[1]->ToObject();
+  Bytef* in_buf  = (Bytef*)node::Buffer::Data(input);
+  Bytef* res_buf = (Bytef*)node::Buffer::Data(result);
+  int in_len  = node::Buffer::Length(input);
+  int res_len = node::Buffer::Length(result);
 
   z_stream strm;
   strm.zalloc = Z_NULL;
@@ -39,8 +44,10 @@ NAN_METHOD(InflateRawSync) {
   strm.next_in = Z_NULL;
 
   int ret = inflateInit2(&strm, -15);
-  if (ret != Z_OK)
-    return ERR("could not initialize the data");
+  if (ret != Z_OK){
+    Nan::ThrowError("Could not decompress from buffer using zlib!");
+    return;
+  }
 
   strm.avail_in = in_len;
   strm.next_in = in_buf;
@@ -48,17 +55,21 @@ NAN_METHOD(InflateRawSync) {
   strm.next_out = res_buf;
 
   ret = inflate(&strm, Z_NO_FLUSH);
-  if (ret != Z_STREAM_END && ret != Z_OK)
-    return ERR("Invalid format");
+  if (ret != Z_STREAM_END && ret != Z_OK){
+    Nan::ThrowError("Could not decompress completely from buffer using zlib!");
+    return;
+  }
+    
 
   (void)inflateEnd(&strm);
-  NanReturnValue(NanNew<Number>(res_len - strm.avail_out));
+
+  info.GetReturnValue().Set(Nan::New<Number>(res_len - strm.avail_out));
 }
 
 // exposing
-void InitAll(Handle<Object> exports) {
-  exports->Set(NanNew<String>("inflateRawSync"),
-    NanNew<FunctionTemplate>(InflateRawSync)->GetFunction());
+void Init(v8::Local<v8::Object> exports){
+  exports->Set(Nan::New("inflateRawSync").ToLocalChecked(),
+	       Nan::New<v8::FunctionTemplate>(inflateRawSync)->GetFunction());
 }
 
-NODE_MODULE(bgzf, InitAll)
+NODE_MODULE(bgzf, Init)


### PR DESCRIPTION
I encountered some issues installing bgzf on CentOS 6 using Node v4. Eventually I discovered that the issues were related to my C compiler and the library NAN. The addresses issue #2 .

1. I needed to specify more modern C++ libraries, such as 4.9.0 in my environment.
2. The `*` character in package.json for Nan was replaced with major release v2, and the syntax has changed dramatically.
3. I updated the function declarations/exports to match the Nan v2 syntax.